### PR TITLE
support windows compilation with msvc

### DIFF
--- a/ext/gc_tracer/extconf.rb
+++ b/ext/gc_tracer/extconf.rb
@@ -61,11 +61,13 @@ open("gc_tracer.h", 'w'){|f|
     GC.latest_gc_info.keys.each.with_index{|k, i|
       f.puts "    sym_latest_gc_info[#{i}] = ID2SYM(rb_intern(\"#{k}\"));"
     }
-    f.puts "    sym_rusage_timeval[0] = ID2SYM(rb_intern(\"ru_utime\"));"
-    f.puts "    sym_rusage_timeval[1] = ID2SYM(rb_intern(\"ru_stime\"));"
-    rusage_members.each.with_index{|k, i|
-      f.puts "    sym_rusage[#{i}] = ID2SYM(rb_intern(\"#{k}\"));"
-    }
+    unless rusage_members.empty?
+      f.puts "    sym_rusage_timeval[0] = ID2SYM(rb_intern(\"ru_utime\"));"
+      f.puts "    sym_rusage_timeval[1] = ID2SYM(rb_intern(\"ru_stime\"));"
+      rusage_members.each.with_index{|k, i|
+        f.puts "    sym_rusage[#{i}] = ID2SYM(rb_intern(\"#{k}\"));"
+      }
+    end
     #
   f.puts "}"
 }

--- a/ext/gc_tracer/gc_logging.c
+++ b/ext/gc_tracer/gc_logging.c
@@ -161,7 +161,7 @@ timeval2double(struct timeval *tv)
 {
     return tv->tv_sec * 1000000LL + tv->tv_usec;
 }
-
+#if HAVE_GETRUSAGE
 static void
 fill_rusage(struct gc_logging *logging)
 {
@@ -170,7 +170,7 @@ fill_rusage(struct gc_logging *logging)
 	getrusage(RUSAGE_SELF, &logging->rusage);
     }
 }
-
+#endif
 static void
 out_time_none(FILE *out)
 {
@@ -253,6 +253,7 @@ out_gc_latest_gc_info(struct gc_logging *logging)
     }
 }
 
+#if HAVE_GETRUSAGE
 static void
 out_rusage(struct gc_logging *logging)
 {
@@ -305,6 +306,7 @@ out_rusage(struct gc_logging *logging)
 #endif
 
 }
+#endif
 
 static void
 out_stat(struct gc_logging *logging, const char *event)


### PR DESCRIPTION
windows, lacking rusage support, requires that the structure not
include the rusage members, and additionally, that functions within
the extension that refer to rusage structures and functions be wrapped
in conditional compilation directives.