### PR TITLE
Update tested rubies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: ruby
 rvm:
-  - 2.1.0
-  - 2.2.0
-  - 2.3.0
+  - '2.5'
+  - '2.6'
+  - '2.7'
 before_install:
   - gem update bundler


### PR DESCRIPTION
I hoped the test suite would show failures on 2.7 (https://github.com/ko1/gc_tracer/issues/14), but apparently it's passing fine.